### PR TITLE
Parallelization of heat conductivity calculation

### DIFF
--- a/curp/console.py
+++ b/curp/console.py
@@ -196,10 +196,6 @@ def arg_cal_tc(parser=None):
                         action='store_true', required=False,
                         help='turn on debug mode.')
 
-    parser.add_argument('--no-axes', dest='no_axes',
-                        action='store_true', required=False,
-                        help='with this option, scalar flux is handled.')
-
     if return_parser:
         return parser
 

--- a/curp/script/cal_tc.py
+++ b/curp/script/cal_tc.py
@@ -61,9 +61,9 @@ def gen_fluxdata(flux_fn):
     ncfile.close()
 
     tsum = 0.0
-    for ipair_1, (don, acc) in enumerate(zip(donors, acceptors)):
+    for ipair_1, (donor, acceptor) in enumerate(zip(donors, acceptors)):
         print('loading for {}/{} {} {} ... ** '
-              .format(ipair_1+1, npair, don, acc), end='')
+              .format(ipair_1+1, npair, donor, acceptor), end='')
         sys.stdout.flush()
 
         t_1 = time.time()
@@ -80,7 +80,7 @@ def gen_fluxdata(flux_fn):
         print('load time: {:.3f} [s]'.format(t_2-t_1))
         tsum += t_2-t_1
 
-        yield don, acc, flux, no_axes
+        yield donor, acceptor, flux, no_axes
 
     print('total load time: {:.3f} [s]'.format(tsum))
 
@@ -103,7 +103,7 @@ class TransportCoefficientCalculator:
 
     def run_mpi(self, data, **other):
         t_0 = time.time()
-        don, acc, flux, no_axes = data
+        donor, acceptor, flux, no_axes = data
 
         if no_axes:
             acf = cal_acf(flux, self.nframe_acf,
@@ -118,8 +118,8 @@ class TransportCoefficientCalculator:
         transport_coefficient = self.__coef * self.d_t * pico_in_femto * numpy.trapz(acf,axis=0)[0]
 
         print('    cal time: {:.3f} [s] for {} {}'
-              .format(time.time()-t_0, don, acc))
-        return don, acc, transport_coefficient, acf
+              .format(time.time()-t_0, donor, acceptor))
+        return donor, acceptor, transport_coefficient, acf
 
     def get_times(self):
         return numpy.arange(0.0, self.nframe_acf*self.d_t, self.d_t)

--- a/curp/script/lib_hfacf.f90
+++ b/curp/script/lib_hfacf.f90
@@ -9,22 +9,8 @@ subroutine cal_hfacf(acf, xss, nacf, first, last, interval, shift, &
    logical, optional, intent(in) :: norm
    real(8), intent(out):: acf(nacf, ncom)
 
-   real(8) :: x2_sum_inv(ncom), acf_tmp(nacf, ncom), temp(ncom)
-   integer :: iacf, ifrm, ifrm_beg, nfrm_beg, icom, nsam, i
-   logical :: use_norm
-   real(8) :: a, norm_flg, b(ncom)
-
-   ! determine the default value of use_norm
-   ! if ( norm .eqv. .true. ) then
-   !    use_norm = norm
-   !    norm_flg = 1.0d0
-   ! else
-   !    use_norm = .false.
-   !    norm_flg = 0.0d0
-   ! end if
-
-   ! Normalization is disabled
-   norm_flg = 0.0d0
+   integer :: iacf, ifrm, ifrm_beg, nfrm_beg, icom, nsam
+   real(8) :: a
 
    ! determine the number of samples
    if ( nsample <= 0 ) then
@@ -42,19 +28,10 @@ subroutine cal_hfacf(acf, xss, nacf, first, last, interval, shift, &
          b(icom)=0.0d0
          do ifrm_beg=first, nfrm_beg, shift
 
-            ! if use_norm then x2_sum_inv = 1/h(0)h(0) else x2_sum_inv = 1.0d0            
-            
-            x2_sum_inv(icom) = 1.0d0/(xss(ifrm_beg,1,icom)**2 &
-                                    + xss(ifrm_beg,2,icom)**2 &
-                                    + xss(ifrm_beg,3,icom)**2)
-            x2_sum_inv(icom) = x2_sum_inv(icom) - 1.0d0
-            x2_sum_inv(icom) = (x2_sum_inv(icom) * norm_flg) + 1.0d0
-
-            ifrm = ifrm_beg+(iacf-1)*interval
-            a = a + ( xss(ifrm_beg,1,icom)*xss(ifrm,1,icom) &
-                    + xss(ifrm_beg,2,icom)*xss(ifrm,2,icom) &
-                    + xss(ifrm_beg,3,icom)*xss(ifrm,3,icom) ) * x2_sum_inv(icom)
-            b(icom) = b(icom) + (1.0d0/x2_sum_inv(icom))
+            ifrm = ifrm_beg + (iacf - 1) * interval
+            a = a + xss(ifrm_beg,1,icom) * xss(ifrm,1,icom) &
+                  + xss(ifrm_beg,2,icom) * xss(ifrm,2,icom) &
+                  + xss(ifrm_beg,3,icom) * xss(ifrm,3,icom)
 
          end do
   
@@ -65,8 +42,5 @@ subroutine cal_hfacf(acf, xss, nacf, first, last, interval, shift, &
    end do ! samples of one file data
 
    nsam = (nfrm_beg-first)/shift + 1
-   ! print*, first, nfrm_beg, nsam
    acf(:,:) = acf(:,:) / real(nsam)
-   b(:) = b(:) / real(nsam)
-   ! print*, '<h(0)h(0)> = ',b(1)
 end subroutine

--- a/curp/script/lib_hfacf.f90
+++ b/curp/script/lib_hfacf.f90
@@ -2,6 +2,7 @@
 subroutine cal_hfacf(acf, xss, nacf, first, last, interval, shift, &
                    & norm, nsample, ndim, nframe, ncom)
 
+   use omp_lib
    implicit none
    integer, intent(in) :: nacf, first, last, interval
    integer, intent(in) :: shift, nframe, ncom, nsample, ndim
@@ -21,8 +22,9 @@ subroutine cal_hfacf(acf, xss, nacf, first, last, interval, shift, &
       nfrm_beg = first + shift*(nsample-1)
    end if
 
+   !$omp parallel private(icom, iacf, ifrm_beg, a, ifrm)
+   !$omp do
    do icom=1, ncom
-
       do iacf=1, nacf
          a = 0.0d0 
          do ifrm_beg=first, nfrm_beg, shift
@@ -33,12 +35,11 @@ subroutine cal_hfacf(acf, xss, nacf, first, last, interval, shift, &
                   + xss(ifrm_beg,3,icom) * xss(ifrm,3,icom)
 
          end do
-  
          acf(iacf,icom) = a
-
       end do
-
    end do ! samples of one file data
+   !$omp end do
+   !$omp end parallel
 
    nsam = (nfrm_beg-first)/shift + 1
    acf(:,:) = acf(:,:) / real(nsam)

--- a/curp/script/lib_hfacf.f90
+++ b/curp/script/lib_hfacf.f90
@@ -25,7 +25,6 @@ subroutine cal_hfacf(acf, xss, nacf, first, last, interval, shift, &
 
       do iacf=1, nacf
          a = 0.0d0 
-         b(icom)=0.0d0
          do ifrm_beg=first, nfrm_beg, shift
 
             ifrm = ifrm_beg + (iacf - 1) * interval

--- a/curp/script/lib_hfacf.f90
+++ b/curp/script/lib_hfacf.f90
@@ -22,9 +22,10 @@ subroutine cal_hfacf(acf, xss, nacf, first, last, interval, shift, &
       nfrm_beg = first + shift*(nsample-1)
    end if
 
-   !$omp parallel private(icom, iacf, ifrm_beg, a, ifrm)
-   !$omp do
+
    do icom=1, ncom
+      !$omp parallel private(iacf, ifrm_beg, a, ifrm)
+      !$omp do
       do iacf=1, nacf
          a = 0.0d0 
          do ifrm_beg=first, nfrm_beg, shift
@@ -37,9 +38,9 @@ subroutine cal_hfacf(acf, xss, nacf, first, last, interval, shift, &
          end do
          acf(iacf,icom) = a
       end do
+      !$omp end do
+      !$omp end parallel
    end do ! samples of one file data
-   !$omp end do
-   !$omp end parallel
 
    nsam = (nfrm_beg-first)/shift + 1
    acf(:,:) = acf(:,:) / real(nsam)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ def ext_modules(config, _dir):
                 ext_name = os.path.splitext(f90_file)[0].replace("/", ".")
                 config.add_extension(ext_name,
                                      [f90_file],
-                                     f2py_options=['--quiet']
+                                     f2py_options=["--quiet"],
+                                     extra_f90_compile_args=["-fopenmp"]
                                     )
 
 with open('README.rst', 'r') as summary:


### PR DESCRIPTION
Heat conductivity calculation had been parallelized using MPI but the parallelization divide pairs. I focused on Auto Correlation function calculation.
- Parallelization of heat conductivity calculation using OpenMP
- Add build option (setup.py) to use OpenMP
- Avoid using `--no-axes` option because it can be detected by program without user specification.