### PR TITLE
delete : conda install curp

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -27,7 +27,7 @@ Installation
 Pip
 ---
 
-Run ``pip install Curp`` or any flavor of pip (``conda install curp``, ``pip install --user curp``, ``pipenv install curp``, ...) 
+Run ``pip install Curp`` or any flavor of pip (``pip install --user curp``, ``pipenv install curp``, ...) 
 
 Git
 ---


### PR DESCRIPTION
I request you to delete `conda install curp` from `docs/source/install.rst` because we cannot do this with Anaconda / Miniconda. 