### PR TITLE
write_array method in compute.py fixed

### DIFF
--- a/curp/compute.py
+++ b/curp/compute.py
@@ -59,7 +59,7 @@ def write_array(array, num_per_line=10):
 
         # Last line
         if length % num_per_line != 0:
-            icol_beg = 10 * (length//num_per_line+1)
+            icol_beg = 10 * (length//num_per_line)
             line = ' '.join('{:>5}'.format(col)
                             for col in array[icol_beg:])
             logger.info(line)


### PR DESCRIPTION
The last line of the target_atom list of log file did not appear if the number of atoms in the last line is not multiple of 10.