### PR TITLE
fix output of flux.log

### DIFF
--- a/curp/compute.py
+++ b/curp/compute.py
@@ -566,7 +566,7 @@ def curp(input_="run.cfg", use_serial=False, vervose=False,
         license_fp = os.path.join(SRC_DIR, "LICENSE-short.txt")
         with open(license_fp, "r", encoding="utf-8") as license_file:
             for line in license_file:
-                logger.info(" "*8 + str(line.strip().encode('utf-8')))
+                logger.info(" "*8 +line.strip())
         logger.info()
         logger.info()
 

--- a/curp/compute.py
+++ b/curp/compute.py
@@ -298,7 +298,7 @@ def init_current(setting, par):
     # Decide Writer.
     t_0 = time.time()
     
-    logger.info("length of gpair_table: {}".format(len(gpair_table)))
+    logger.info("length of gpair_table: {}".format(len(interact_table)))
 
     if par.is_root():
         from curp.current.writer import get_writer

--- a/curp/compute.py
+++ b/curp/compute.py
@@ -298,7 +298,7 @@ def init_current(setting, par):
     # Decide Writer.
     t_0 = time.time()
     
-    logger.info("length of gpair_table: {}".format(len(interact_table)))
+    logger.info("length of nonbonded_table: {}".format(len(interact_table)))
 
     if par.is_root():
         from curp.current.writer import get_writer

--- a/curp/setting.py
+++ b/curp/setting.py
@@ -463,8 +463,11 @@ def parse_config(config_filename=None):
                 outfile.write(body)
 
         outfile.seek(0)
-    print("Type outfile: ", type(outfile))
-    print(outfile)
+    
+    import curp.clog as logger
+    logger.debug("Type outfile: ", type(outfile))
+    logger.debug(outfile)
+    
     config = cp.SafeConfigParser()
 
     config.readfp(outfile)


### PR DESCRIPTION
This pull request is about fix output of flux.log.
It contains below:
- fixed output format of license
- modified print function to debug output
- fixed reference variable of length of nonbonded gpair_table