### PR TITLE
Hotfix/ignore dev files on master branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ tutorial
 
 # Ignore doc outputs
 _build/
+
+.vscode/
+venv/
+.venv/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Ignores library files
 **.so
 **.pyc
+__pycache__/
 
 # Ignores curp-environ and tutorial directory
 curp-environ/


### PR DESCRIPTION
## Why
- Some common files generated through the development process in Python have been left from gitignore
- We should ignore files on master branch as well.

## Changes
- Updated `.gitignore` file