### PR TITLE
[WIP] add: github actions yaml file to generate built package files

### DIFF
--- a/.github/workflows/create_built_package.yaml
+++ b/.github/workflows/create_built_package.yaml
@@ -49,9 +49,8 @@ jobs:
       
       - name: Check external libraries are bundled
         run: |
-          cd dist
-          unzip -l Curp-*.whl | grep "\.so"
-          auditwheel show Curp-*.whl
+          unzip -l .dist/Curp-*.whl | grep "\.so"
+          auditwheel show .dist/Curp-*.whl
 
       - name: Upload artifacts to dist/ directory
         uses: actions/upload-artifact@v4

--- a/.github/workflows/create_built_package.yaml
+++ b/.github/workflows/create_built_package.yaml
@@ -19,11 +19,8 @@ jobs:
     
       - name: Install building dependencies (cibuildwheel, etc.)
         run: |
-          python -m venv venv
-          source venv/bin/activate
-          python -m pip install -U pip setuptools wheel
           python -m pip install -U cibuildwheel
 
-      - name: Build wheel using cibuildwheel
+      - name: Build wheels using cibuildwheel
         run: |
           python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/create_built_package.yaml
+++ b/.github/workflows/create_built_package.yaml
@@ -47,8 +47,8 @@ jobs:
           CIBW_BEFORE_ALL_LINUX: |
             yum update -y
             yum install -y yum-utils wget
-            wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-            yum install -y ./epel-release-latest-7.noarch.rpm
+            wget https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm
+            yum install -y ./epel-release-7-14.noarch.rpm
             yum install -y netcdf-devel graphviz-devel openmpi-devel
         with:
           output-dir: ./dist

--- a/.github/workflows/create_built_package.yaml
+++ b/.github/workflows/create_built_package.yaml
@@ -2,8 +2,8 @@ name: Create built CURP package (wheel files) for PyPI distribution
 
 on:
   push:
-    branches:
-      - feature/generate-built-package-automatically
+    tags:
+      - "v*"
 
 jobs:
   build_wheels:
@@ -62,3 +62,10 @@ jobs:
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./dist/*.whl
+
+      - name: Upload built package to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/create_built_package.yaml
+++ b/.github/workflows/create_built_package.yaml
@@ -46,7 +46,9 @@ jobs:
           CIBW_BUILD_VERBOSITY: 3
           CIBW_BEFORE_ALL_LINUX: |
             yum update -y
-            yum install -y epel-release
+            yum install -y yum-utils wget
+            wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+            yum install -y ./epel-release-latest-7.noarch.rpm
             yum install -y netcdf-devel graphviz-devel openmpi-devel
         with:
           output-dir: ./dist

--- a/.github/workflows/create_built_package.yaml
+++ b/.github/workflows/create_built_package.yaml
@@ -66,7 +66,7 @@ jobs:
   publish-to-testpypi:
     name: Publish to TestPyPI
     needs:
-      - build
+      - build_wheels
     runs-on: ubuntu-latest
 
     environment:

--- a/.github/workflows/create_built_package.yaml
+++ b/.github/workflows/create_built_package.yaml
@@ -2,8 +2,8 @@ name: Create built CURP package (wheel files) for distribution
 
 on:
   push:
-    tags:
-      - test*
+    branches:
+      - feature/generate-built-package-automatically
 
 jobs:
   manylinux-build:

--- a/.github/workflows/create_built_package.yaml
+++ b/.github/workflows/create_built_package.yaml
@@ -62,8 +62,28 @@ jobs:
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./dist/*.whl
+  
+  publish-to-testpypi:
+    name: Publish to TestPyPI
+    needs:
+      - build
+    runs-on: ubuntu-latest
 
-      - name: Upload built package to TestPyPI
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/Curp/
+
+    permissions:
+      id-token: write  # mandatory for trusted publishing
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish distribution to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__

--- a/.github/workflows/create_built_package.yaml
+++ b/.github/workflows/create_built_package.yaml
@@ -3,7 +3,7 @@ name: Create built CURP package (wheel files) for PyPI distribution
 on:
   push:
     tags:
-      - "v*"
+      - "release-test/*"
 
 jobs:
   build_wheels:

--- a/.github/workflows/create_built_package.yaml
+++ b/.github/workflows/create_built_package.yaml
@@ -16,7 +16,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
+
+      - name: Install build dependencies for ${{ matrix.os }}
+        run: |
+          if [[ ${{ matrix.os }} == "ubuntu-20.04" ]]; then
+            sudo apt-get update
+            sudo apt-get install -y build-essential gfortran libnetcdf-dev libhdf5-dev graphviz-dev libopenmpi-dev
+          elif [[ ${{ matrix.os }} == "macos-13" ]]; then
+            brew install gcc netcdf graphviz open-mpi
+          fi
+
       - name: Build wheels using cibuildwheel
         uses: pypa/cibuildwheel@v2.22.0
         env:

--- a/.github/workflows/create_built_package.yaml
+++ b/.github/workflows/create_built_package.yaml
@@ -86,8 +86,6 @@ jobs:
       - name: Publish distribution to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.TESTPYPI_ACCESS_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
 
   github-release:

--- a/.github/workflows/create_built_package.yaml
+++ b/.github/workflows/create_built_package.yaml
@@ -45,6 +45,8 @@ jobs:
           CIBW_BUILD: cp36-*
           CIBW_BUILD_VERBOSITY: 3
           CIBW_BEFORE_ALL_LINUX: |
+            yum update -y
+            yum install -y epel-release
             yum install -y netcdf-devel graphviz-devel openmpi-devel
         with:
           output-dir: ./dist

--- a/.github/workflows/create_built_package.yaml
+++ b/.github/workflows/create_built_package.yaml
@@ -42,6 +42,7 @@ jobs:
       - name: Build wheels using cibuildwheel
         uses: pypa/cibuildwheel@v2.22.0
         env:
+          CIBW_ARCHS: x86_64
           CIBW_BUILD: cp36-*
           CIBW_BUILD_VERBOSITY: 3
           CIBW_BEFORE_ALL_LINUX: |

--- a/.github/workflows/create_built_package.yaml
+++ b/.github/workflows/create_built_package.yaml
@@ -44,6 +44,8 @@ jobs:
         env:
           CIBW_BUILD: cp36-*
           CIBW_BUILD_VERBOSITY: 3
+          CIBW_BEFORE_ALL_LINUX: |
+            yum install -y netcdf-devel graphviz-devel openmpi-devel
         with:
           output-dir: ./dist
       

--- a/.github/workflows/create_built_package.yaml
+++ b/.github/workflows/create_built_package.yaml
@@ -24,7 +24,16 @@ jobs:
             sudo apt-get install -y build-essential gfortran libnetcdf-dev libhdf5-dev graphviz-dev libopenmpi-dev
           elif [[ ${{ matrix.os }} == "macos-13" ]]; then
             brew install gcc netcdf graphviz open-mpi
+            # Ensure gfortran is linked correctly
+            brew link --overwrite gcc
+            # Add gfortran to PATH
+            echo 'export PATH="/usr/local/bin:$PATH"' >> $GITHUB_ENV
           fi
+
+      - name: Verify gfortran installation
+        run: |
+          gfortran --version
+          which gfortran
 
       - name: Build wheels using cibuildwheel
         uses: pypa/cibuildwheel@v2.22.0

--- a/.github/workflows/create_built_package.yaml
+++ b/.github/workflows/create_built_package.yaml
@@ -71,7 +71,7 @@ jobs:
 
     environment:
       name: testpypi
-      url: https://test.pypi.org/p/Curp/
+      url: https://test.pypi.org/p/curp-v2-test/
 
     permissions:
       id-token: write  # mandatory for trusted publishing
@@ -89,3 +89,28 @@ jobs:
           user: __token__
           password: ${{ secrets.TESTPYPI_ACCESS_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
+
+  github-release:
+    name: Create GitHub Release
+    needs:
+      - publish-to-testpypi
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      
+      - name: Create a release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create ${{ github.ref_name }} \
+            --generate-notes \
+            --title "Release for version ${{ github.ref_name }}" \
+            --notes "Release notes for version ${{ github.ref_name }}"

--- a/.github/workflows/create_built_package.yaml
+++ b/.github/workflows/create_built_package.yaml
@@ -7,21 +7,28 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }} for ${{ matrix.platform }} ${{ matrix.arch }}
-    runs-on: ubuntu-20.04
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        platform: [manylinux, musllinux]
-        arch: [x86_64, i686]
+        os: [ubuntu-20.04]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install build dependencies
+      - name: Install build dependencies for ${{ matrix.os }}
         run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential gfortran libnetcdf-dev libhdf5-dev graphviz-dev libopenmpi-dev
+          if [[ ${{ matrix.os }} == "ubuntu-20.04" ]]; then
+            sudo apt-get update
+            sudo apt-get install -y build-essential gfortran libnetcdf-dev libhdf5-dev graphviz-dev libopenmpi-dev
+          elif [[ ${{ matrix.os }} == "macos-13" ]]; then
+            brew install gcc netcdf graphviz open-mpi
+            # Ensure gfortran is linked correctly
+            brew link --overwrite gcc
+            # Add gfortran to PATH
+            echo "export PATH=\"$(brew --prefix gcc)/bin:\$PATH\"" >> $GITHUB_ENV
+          fi
 
       - name: Install auditwheel
         run: |
@@ -36,9 +43,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_BUILD: cp36-*
-          CIBW_BUILD_VERBOSITY: 1
-          CIBW_ARCHS: ${{ matrix.arch }}
-          CIBW_PLATFORM: ${{ matrix.platform }}
+          CIBW_BUILD_VERBOSITY: 3
         with:
           output-dir: ./temp
 
@@ -49,5 +54,5 @@ jobs:
       - name: Upload artifacts to dist/ directory
         uses: actions/upload-artifact@v4
         with:
-          name: cibw-wheels-${{ matrix.platform }}-${{ matrix.arch }}
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./dist/*.whl

--- a/.github/workflows/create_built_package.yaml
+++ b/.github/workflows/create_built_package.yaml
@@ -7,28 +7,21 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: Build wheels on ${{ matrix.os }} for ${{ matrix.platform }} ${{ matrix.arch }}
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        platform: [manylinux, musllinux]
+        arch: [x86_64, i686]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install build dependencies for ${{ matrix.os }}
+      - name: Install build dependencies
         run: |
-          if [[ ${{ matrix.os }} == "ubuntu-20.04" ]]; then
-            sudo apt-get update
-            sudo apt-get install -y build-essential gfortran libnetcdf-dev libhdf5-dev graphviz-dev libopenmpi-dev
-          elif [[ ${{ matrix.os }} == "macos-13" ]]; then
-            brew install gcc netcdf graphviz open-mpi
-            # Ensure gfortran is linked correctly
-            brew link --overwrite gcc
-            # Add gfortran to PATH
-            echo "export PATH=\"$(brew --prefix gcc)/bin:\$PATH\"" >> $GITHUB_ENV
-          fi
+          sudo apt-get update
+          sudo apt-get install -y build-essential gfortran libnetcdf-dev libhdf5-dev graphviz-dev libopenmpi-dev
 
       - name: Install auditwheel
         run: |
@@ -44,6 +37,8 @@ jobs:
         env:
           CIBW_BUILD: cp36-*
           CIBW_BUILD_VERBOSITY: 1
+          CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_PLATFORM: ${{ matrix.platform }}
         with:
           output-dir: ./temp
 
@@ -54,5 +49,5 @@ jobs:
       - name: Upload artifacts to dist/ directory
         uses: actions/upload-artifact@v4
         with:
-          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          name: cibw-wheels-${{ matrix.platform }}-${{ matrix.arch }}
           path: ./dist/*.whl

--- a/.github/workflows/create_built_package.yaml
+++ b/.github/workflows/create_built_package.yaml
@@ -49,8 +49,12 @@ jobs:
       
       - name: Check external libraries are bundled
         run: |
-          unzip -l .dist/Curp-*.whl | grep "\.so"
-          auditwheel show .dist/Curp-*.whl
+          for whl in dist/Curp-*.whl; do
+            echo "=== Inspecting $whl ==="
+            unzip -l "$whl" | grep "\.so" || echo "(No .so found)"
+            auditwheel show "$whl"
+            echo
+          done
 
       - name: Upload artifacts to dist/ directory
         uses: actions/upload-artifact@v4

--- a/.github/workflows/create_built_package.yaml
+++ b/.github/workflows/create_built_package.yaml
@@ -87,5 +87,5 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          password: ${{ secrets.TESTPYPI_ACCESS_TOKEN }}
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/create_built_package.yaml
+++ b/.github/workflows/create_built_package.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   manylinux-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/create_built_package.yaml
+++ b/.github/workflows/create_built_package.yaml
@@ -45,11 +45,13 @@ jobs:
           CIBW_BUILD: cp36-*
           CIBW_BUILD_VERBOSITY: 3
         with:
-          output-dir: ./temp
-
-      - name: Include external dependencies
+          output-dir: ./dist
+      
+      - name: Check external libraries are bundled
         run: |
-          auditwheel repair ./temp/*.whl -w ./dist
+          cd dist
+          unzip -l Curp-*.whl | grep "\.so"
+          auditwheel show Curp-*.whl
 
       - name: Upload artifacts to dist/ directory
         uses: actions/upload-artifact@v4

--- a/.github/workflows/create_built_package.yaml
+++ b/.github/workflows/create_built_package.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Upload artifacts to dist/ directory
         uses: actions/upload-artifact@v4
         with:
-          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          name: python-package-distributions
           path: ./dist/*.whl
   
   publish-to-testpypi:

--- a/.github/workflows/create_built_package.yaml
+++ b/.github/workflows/create_built_package.yaml
@@ -21,10 +21,9 @@ jobs:
         run: |
           python -m venv venv
           source venv/bin/activate
-          pip install -U pip setuptools wheel
-          pip install -U cibuildwheel
+          python -m pip install -U pip setuptools wheel
+          python -m pip install -U cibuildwheel
 
       - name: Build wheel using cibuildwheel
         run: |
-          cibuildwheel --output-dir wheelhouse .
-
+          python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/create_built_package.yaml
+++ b/.github/workflows/create_built_package.yaml
@@ -1,4 +1,4 @@
-name: Create built CURP package (wheel files) for distribution
+name: Create built CURP package (wheel files) for PyPI distribution
 
 on:
   push:
@@ -6,24 +6,27 @@ on:
       - feature/generate-built-package-automatically
 
 jobs:
-  manylinux-build:
-    runs-on: ubuntu-20.04
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, macos-13]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.6
-    
-      - name: Install building dependencies (cibuildwheel, etc.)
-        run: |
-          python -m pip install -U cibuildwheel
-
+      
       - name: Build wheels using cibuildwheel
-        run: |
-          python -m cibuildwheel --output-dir wheelhouse
+        uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_BUILD: cp36-*
           CIBW_BUILD_VERBOSITY: 1
+        with:
+          output-dir: ./dist
+
+      - name: Upload artifacts to dist/ directory
+        uses: actions/upload-artifact@v4
+        with:
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          path: ./dist/*.whl

--- a/.github/workflows/create_built_package.yaml
+++ b/.github/workflows/create_built_package.yaml
@@ -1,0 +1,30 @@
+name: Create built CURP package (wheel files) for distribution
+
+on:
+  push:
+    tags:
+      - test*
+
+jobs:
+  manylinux-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.6
+    
+      - name: Install building dependencies (cibuildwheel, etc.)
+        run: |
+          python -m venv venv
+          source venv/bin/activate
+          pip install -U pip setuptools wheel
+          pip install -U cibuildwheel
+
+      - name: Build wheel using cibuildwheel
+        run: |
+          cibuildwheel --output-dir wheelhouse .
+

--- a/.github/workflows/create_built_package.yaml
+++ b/.github/workflows/create_built_package.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-13]
+        os: [ubuntu-20.04]
 
     steps:
       - name: Checkout
@@ -27,7 +27,7 @@ jobs:
             # Ensure gfortran is linked correctly
             brew link --overwrite gcc
             # Add gfortran to PATH
-            echo 'export PATH="/usr/local/bin:$PATH"' >> $GITHUB_ENV
+            echo "export PATH=\"$(brew --prefix gcc)/bin:\$PATH\"" >> $GITHUB_ENV
           fi
 
       - name: Verify gfortran installation

--- a/.github/workflows/create_built_package.yaml
+++ b/.github/workflows/create_built_package.yaml
@@ -45,12 +45,6 @@ jobs:
           CIBW_ARCHS: x86_64
           CIBW_BUILD: cp36-*
           CIBW_BUILD_VERBOSITY: 3
-          CIBW_BEFORE_ALL_LINUX: |
-            yum update -y
-            yum install -y yum-utils wget
-            wget https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm
-            yum install -y ./epel-release-7-14.noarch.rpm
-            yum install -y netcdf-devel graphviz-devel openmpi-devel
         with:
           output-dir: ./dist
       

--- a/.github/workflows/create_built_package.yaml
+++ b/.github/workflows/create_built_package.yaml
@@ -24,3 +24,6 @@ jobs:
       - name: Build wheels using cibuildwheel
         run: |
           python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_BUILD: cp36-*
+          CIBW_BUILD_VERBOSITY: 1

--- a/.github/workflows/create_built_package.yaml
+++ b/.github/workflows/create_built_package.yaml
@@ -30,6 +30,10 @@ jobs:
             echo "export PATH=\"$(brew --prefix gcc)/bin:\$PATH\"" >> $GITHUB_ENV
           fi
 
+      - name: Install auditwheel
+        run: |
+          pip install auditwheel
+
       - name: Verify gfortran installation
         run: |
           gfortran --version
@@ -41,7 +45,11 @@ jobs:
           CIBW_BUILD: cp36-*
           CIBW_BUILD_VERBOSITY: 1
         with:
-          output-dir: ./dist
+          output-dir: ./temp
+
+      - name: Include external dependencies
+        run: |
+          auditwheel repair ./temp/*.whl -w ./dist
 
       - name: Upload artifacts to dist/ directory
         uses: actions/upload-artifact@v4

--- a/.github/workflows/deploy_package.yaml
+++ b/.github/workflows/deploy_package.yaml
@@ -1,4 +1,4 @@
-name: Deploy package to pypi
+name: Deploy package to PyPI and create a GitHub Release
 
 on:
   push:
@@ -6,25 +6,111 @@ on:
       - "v*"
 
 jobs:
-  build-and-deploy:
-    runs-on: ubuntu-18.04
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: "2.7"
+      - name: Install build dependencies for ${{ matrix.os }}
+        run: |
+          if [[ ${{ matrix.os }} == "ubuntu-20.04" ]]; then
+            sudo apt-get update
+            sudo apt-get install -y build-essential gfortran libnetcdf-dev libhdf5-dev graphviz-dev libopenmpi-dev
+          elif [[ ${{ matrix.os }} == "macos-13" ]]; then
+            brew install gcc netcdf graphviz open-mpi
+            # Ensure gfortran is linked correctly
+            brew link --overwrite gcc
+            # Add gfortran to PATH
+            echo "export PATH=\"$(brew --prefix gcc)/bin:\$PATH\"" >> $GITHUB_ENV
+          fi
 
-    - name: Install numpy
-      run: pip install numpy==1.16.6
-    
-    - name: Packaging
-      run: python setup.py sdist
+      - name: Install auditwheel
+        run: |
+          pip install auditwheel
 
-    - name: Publish a distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Verify gfortran installation
+        run: |
+          gfortran --version
+          which gfortran
+
+      - name: Build wheels using cibuildwheel
+        uses: pypa/cibuildwheel@v2.22.0
+        env:
+          CIBW_ARCHS: x86_64
+          CIBW_BUILD: cp36-*
+          CIBW_BUILD_VERBOSITY: 3
+        with:
+          output-dir: ./dist
+      
+      - name: Check external libraries are bundled
+        run: |
+          for whl in dist/Curp-*.whl; do
+            echo "=== Inspecting $whl ==="
+            unzip -l "$whl" | grep "\.so" || echo "(No .so found)"
+            auditwheel show "$whl"
+            echo
+          done
+
+      - name: Upload artifacts to dist/ directory
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: ./dist/*.whl
+  
+  publish-to-pypi:
+    name: Publish to PyPI
+    needs:
+      - build_wheels
+    runs-on: ubuntu-latest
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/Curp/
+
+    permissions:
+      id-token: write  # mandatory for trusted publishing
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          repository-url: https://pypi.org/legacy/
+
+  github-release:
+    name: Create GitHub Release
+    needs:
+      - publish-to-pypi
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      
+      - name: Create a release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create ${{ github.ref_name }} \
+            --generate-notes \
+            --title "Release for version ${{ github.ref_name }}" \
+            --notes "Release notes for version ${{ github.ref_name }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy==1.16"]
+requires = ["setuptools", "wheel", "numpy==1.16", "mpi4py", "netCDF4", "pygraphviz"]
 build-backend = "setuptools.build_meta" 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy==1.16", "mpi4py", "netCDF4", "pygraphviz"]
+requires = ["setuptools", "wheel", "numpy==1.16"]
 build-backend = "setuptools.build_meta" 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ before-all = [
 ]
 
 [[tool.cibuildwheel.overrides]]
-select = "*-musllinux*"
+select = "*-musllinux_*"
 before-all = [
     "apk update",
     "apk add --no-cache netcdf-dev graphviz-dev openmpi-dev"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel.linux]
 before-all = [
-    "yum update -y",
-    "yum install -y yum-utils wget",
-    "wget https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm",
-    "yum install -y ./epel-release-7-14.noarch.rpm",
-    "yum install -y netcdf-devel graphviz-devel openmpi-devel"
+    'yum update -y || true',
+    'yum install -y yum-utils wget || true',
+    'wget https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm || echo "epel-release is already installed, ignoring..."',
+    'yum install -y ./epel-release-7-14.noarch.rpm || true',
+    'yum install -y netcdf-devel graphviz-devel openmpi-devel || true'
 ]
 
 [[tool.cibuildwheel.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,19 @@
 [build-system]
 requires = ["setuptools", "wheel", "numpy==1.16"]
 build-backend = "setuptools.build_meta" 
+
+[tool.cibuildwheel.linux]
+before-all = [
+    "yum update -y",
+    "yum install -y yum-utils wget",
+    "wget https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm",
+    "yum install -y ./epel-release-7-14.noarch.rpm",
+    "yum install -y netcdf-devel graphviz-devel openmpi-devel"
+]
+
+[[tool.cibuildwheel.overrides]]
+select = "*-musllinux*"
+before-all = [
+    "apk update",
+    "apk add --no-cache netcdf-dev graphviz-dev openmpi-dev"
+]

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,33 @@ from _version import __version__
 def ext_modules(config, _dir):
     """Fetch f90 files in src and automatically create an extension"""
     pattern = "*.f90"
+    
+    MPI_DIR = os.environ.get("MPI_DIR", "/usr")
+    NETCDF_DIR = os.environ.get("NETCDF_DIR", "/usr")
+    GRAPHVIZ_DIR = os.environ.get("GRAPHVIZ_DIR", "/usr")
+
+    # Typical library/include paths:
+    mpi_inc = os.path.join(MPI_DIR, "include")
+    mpi_lib = os.path.join(MPI_DIR, "lib")
+    netcdf_inc = os.path.join(NETCDF_DIR, "include")
+    netcdf_lib = os.path.join(NETCDF_DIR, "lib")
+    graphviz_inc = os.path.join(GRAPHVIZ_DIR, "include")
+    graphviz_lib = os.path.join(GRAPHVIZ_DIR, "lib/x86_64-linux-gnu/graphviz")
+    
+    extra_f90_compile_args = [
+        "-O1", 
+        "-fopenmp",
+        f"-I{mpi_inc}",
+        f"-I{netcdf_inc}",
+        f"-I{graphviz_inc}",
+    ]
+    extra_link_args = [
+        "-lgomp",
+        f"-L{mpi_lib}", "-lmpi",
+        f"-L{netcdf_lib}", "-lnetcdf",
+        f"-L{graphviz_lib}", "-lgraphviz",
+    ]
+    
     if os.path.isdir(_dir):
         for root, dirs, files in os.walk(_dir):
             match = fnmatch.filter(files, pattern)


### PR DESCRIPTION
## Why
- We want to distribute pre-built CURP package which includes other dependencies such as mpi4py, pygraphviz and numpy to reduce efforts when installing CURP on machines

## Changes
- Added: new Github Actions workflow to test generating pre-built package for `manylinux` using `cibuildwheel`